### PR TITLE
chore(flake/nixpkgs): `0bb7ec54` -> `e7a3ca80`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -58,11 +58,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1783522502,
-        "narHash": "sha256-iffAls3iaNTyJC2faYcUXSI+Gp02cDjYl+MygxKl2GI=",
+        "lastModified": 1783776592,
+        "narHash": "sha256-UgCQzxeWI75XM8G+hPrPh+MKzEPjG3SpAj7dtqSbksA=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "0bb7ec54c8483066ec9d7720e780a5caa71f8612",
+        "rev": "e7a3ca8092b61ff85b6a45bf863ea2b2d6a661b3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                      |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
| [`308f8d9a`](https://github.com/NixOS/nixpkgs/commit/308f8d9a3ac21b79164274e027ee89c2f3976c84) | `` abtop: 0.5.1 -> 0.5.3 ``                                                                  |
| [`afa865a0`](https://github.com/NixOS/nixpkgs/commit/afa865a008bfc6df7edd15bc1ab5812133cfcdb7) | `` frigate: fix pandas 3.0 compat ``                                                         |
| [`bed56401`](https://github.com/NixOS/nixpkgs/commit/bed56401be941001b9041a55a77a2b72aa78c2a0) | `` arandr: fix build with setuptools 81+ ``                                                  |
| [`0af10bb2`](https://github.com/NixOS/nixpkgs/commit/0af10bb2e8fc9ae0d4686f14c47e2b6f87a322b9) | `` python3Packages.pysmlight: 0.5.2 -> 0.5.3 ``                                              |
| [`e8971b78`](https://github.com/NixOS/nixpkgs/commit/e8971b78f8a690edec12499c5f360e040305ca21) | `` drupal: 11.4.0 -> 11.4.2 ``                                                               |
| [`883e799e`](https://github.com/NixOS/nixpkgs/commit/883e799eb2843d1438a5ce76ed8ac4a924cf6ce5) | `` starship: fix build on Darwin ``                                                          |
| [`1ddea484`](https://github.com/NixOS/nixpkgs/commit/1ddea48416ef1a9ffc7737f8fed6b7a79d945a5d) | `` rumdl: 0.2.27 -> 0.2.30 ``                                                                |
| [`4d85c9c3`](https://github.com/NixOS/nixpkgs/commit/4d85c9c329104d377e8c749985ce5c6b4ce67aad) | `` tbls: 1.94.5 -> 1.95.0 ``                                                                 |
| [`8f6d8af7`](https://github.com/NixOS/nixpkgs/commit/8f6d8af759b39a36a829f6b91b1f08e4b471becb) | `` oha: 1.14.0 -> 1.15.0 ``                                                                  |
| [`2f9abaa7`](https://github.com/NixOS/nixpkgs/commit/2f9abaa7c9557db96b55109013f47e32ec378a89) | `` tui-journal: fix changelog link ``                                                        |
| [`d31766f5`](https://github.com/NixOS/nixpkgs/commit/d31766f550ba6dcf8274a0145efb3526c130913a) | `` python3Packages.aio-geojson-geonetnz-quakes: migrate to finalAttrs ``                     |
| [`c018071a`](https://github.com/NixOS/nixpkgs/commit/c018071afdf52c883c59ad96f3675d4e812c5209) | `` python3Packages.rns: 1.3.7 -> 1.3.8 ``                                                    |
| [`59df8b49`](https://github.com/NixOS/nixpkgs/commit/59df8b49b8e979850bee10a6f664a0af7a42eb68) | `` python3Packages.aio-geojson-geonetnz-quakes: 0.17 -> 2026.6.0 ``                          |
| [`e320f78e`](https://github.com/NixOS/nixpkgs/commit/e320f78e6f0ceceb9e7eede6018761da843f4ae0) | `` python3Packages.aio-geojson-geonetnz-volcano: migrate to finalAttrs ``                    |
| [`118b34d3`](https://github.com/NixOS/nixpkgs/commit/118b34d3ac6f6431a6c44c1606093fa926f5e5cc) | `` python3Packages.aio-geojson-geonetnz-volcano: 0.10 -> 2026.6.0 ``                         |
| [`d44c2493`](https://github.com/NixOS/nixpkgs/commit/d44c24932f295a33a630743f733372aabe0f83b0) | `` python3Packages.aio-geojson-nsw-rfs-incidents: migrate to finalAttrs ``                   |
| [`c348d152`](https://github.com/NixOS/nixpkgs/commit/c348d152afab31d5fb43dbc4a32eeb880e3235ce) | `` python3Packages.aio-geojson-nsw-rfs-incidents: 0.8 -> 2026.6.0 ``                         |
| [`796c8261`](https://github.com/NixOS/nixpkgs/commit/796c8261f4ad2efdbd48064e424279b62d83728a) | `` python3Packages.gftools: 0.9.995 -> 0.9.996 ``                                            |
| [`3597324a`](https://github.com/NixOS/nixpkgs/commit/3597324a1f0e249c533aaae169d7d76fc33bf865) | `` python3Packages.aio-geojson-usgs-earthquakes: migrate to finalAttrs ``                    |
| [`3597a36f`](https://github.com/NixOS/nixpkgs/commit/3597a36fd10913c29e747f82a33df9f9ffd4928e) | `` python3Packages.aio-geojson-usgs-earthquakes: 0.4 -> 2026.6.0 ``                          |
| [`716881fc`](https://github.com/NixOS/nixpkgs/commit/716881fcc11d5c06ff6b517e3b91b3ed363f3845) | `` home-assistant-custom-lovelace-modules.universal-remote-card: 4.11.3 -> 4.11.4 ``         |
| [`54493775`](https://github.com/NixOS/nixpkgs/commit/54493775557218b981217b33d5d4b4f4bb9884f5) | `` python3Packages.aio-georss-gdacs: migrate to finalAttrs ``                                |
| [`c7277538`](https://github.com/NixOS/nixpkgs/commit/c727753829536bc70cd981199887bbbe1e44f35e) | `` python3Packages.aio-georss-gdacs: 0.10 -> 2026.6.0 ``                                     |
| [`74259288`](https://github.com/NixOS/nixpkgs/commit/742592884856865f00138491846f8d18bda0ddf2) | `` python3Packages.aio-georss-client: migrate to finalAttrs ``                               |
| [`938c37a8`](https://github.com/NixOS/nixpkgs/commit/938c37a807fbc0b9359548c9d6fe77427eca69b3) | `` python3Packages.aio-georss-client: 0.14 -> 2026.6.0 ``                                    |
| [`ec4624a4`](https://github.com/NixOS/nixpkgs/commit/ec4624a491adccf42a12b1e26c5b5b6f6cb9b925) | `` python3Packages.aio-geojson-generic-client: migrate to finalAttrs ``                      |
| [`73ee1fa2`](https://github.com/NixOS/nixpkgs/commit/73ee1fa281e5d953c4be2a82eec57d4c6cdaa0d5) | `` python3Packages.aio-geojson-generic-client: 0.5 -> 2026.6.0 ``                            |
| [`0c898ea3`](https://github.com/NixOS/nixpkgs/commit/0c898ea3daa8a42f2d01726b736b952c51d93725) | `` python3Packages.aio-geojson-client: migrate to finalAttrs ``                              |
| [`72b846fd`](https://github.com/NixOS/nixpkgs/commit/72b846fd9b61cb72d5b7ef721ab8ebac4cee68e4) | `` home-assistant-custom-components.cable_modem_monitor: 3.14.0-beta.11 -> 3.14.0-beta.13 `` |
| [`1b542c8a`](https://github.com/NixOS/nixpkgs/commit/1b542c8a7611dad11fd1dde94e1b9142e8e06d32) | `` home-assistant-custom-components.smarthq: 1.2.1 -> 1.2.2 ``                               |
| [`80c6bdfb`](https://github.com/NixOS/nixpkgs/commit/80c6bdfb69113cf11d75796bf92bc942290d7b29) | `` oci-cli: 3.89.0 -> 3.89.1 ``                                                              |
| [`791bff82`](https://github.com/NixOS/nixpkgs/commit/791bff826e7dc39288af12235aaa727e874212ce) | `` subcat: 1.6.0-unstable-2026-06-28 -> 1.6.0 ``                                             |
| [`306c6b3c`](https://github.com/NixOS/nixpkgs/commit/306c6b3c67ac598a894602cd8d0c61d733307252) | `` python3Packages.aio-geojson-client: 0.21 -> 2026.6.0 ``                                   |
| [`d17f2ee9`](https://github.com/NixOS/nixpkgs/commit/d17f2ee9696f4ffcbb9a79f766ecdc12cc62d2a1) | `` chhoto-url: 7.4.1 -> 7.4.10 ``                                                            |
| [`88eb8477`](https://github.com/NixOS/nixpkgs/commit/88eb8477547cd26382ecc3ef68fc1a2c1ba5fbd0) | `` adrs: 0.8.0 -> 0.9.0 ``                                                                   |
| [`0d32eec1`](https://github.com/NixOS/nixpkgs/commit/0d32eec12c8692f1c3901f923bf039e464b33b0c) | `` aws-sam-cli: 1.160.0 -> 1.163.0 ``                                                        |
| [`f30174de`](https://github.com/NixOS/nixpkgs/commit/f30174de616fa12d44f22fecb197b562d905a44b) | `` timoni: 0.26.0 -> 0.27.0 ``                                                               |
| [`14be8178`](https://github.com/NixOS/nixpkgs/commit/14be8178d92f3bb9ec2d0735d42c62293fa7ef37) | `` pdfding: fix build on darwin ``                                                           |
| [`a32ca329`](https://github.com/NixOS/nixpkgs/commit/a32ca329767f7d3f1224b5bdb6fea2059f6f303a) | `` python3Packages.symbolic: 13.7.0 -> 13.9.0 ``                                             |
| [`67ffdc53`](https://github.com/NixOS/nixpkgs/commit/67ffdc5314c9a25b9ea723a5f1df03667793f767) | `` nixos/cinnamon: add system-config-printer to PATH ``                                      |
| [`370d968d`](https://github.com/NixOS/nixpkgs/commit/370d968dd7926cd374ec24509a4b267b607b3916) | `` livekit-cli: 2.16.7 -> 2.17.0 ``                                                          |
| [`ed2e3f58`](https://github.com/NixOS/nixpkgs/commit/ed2e3f583eeeaf6b234035916147a07250b1607b) | `` librewolf-bin-unwrapped: 152.0.4-1 -> 152.0.5-1 ``                                        |
| [`9cb3b65f`](https://github.com/NixOS/nixpkgs/commit/9cb3b65f073b60269ba7dee3e7a7c28b896c1088) | `` warp-terminal: 0.2026.06.24.09.19.stable_03 -> 0.2026.07.08.17.54.stable_02 ``            |
| [`73c62c3e`](https://github.com/NixOS/nixpkgs/commit/73c62c3eb4572c3dae23dda7d1240afa395b103a) | `` cloudlog: 2.8.14 -> 2.8.15 ``                                                             |
| [`b244ad39`](https://github.com/NixOS/nixpkgs/commit/b244ad39216f97a6a331d8b62426960f81067834) | `` discordchatexporter-cli: add phanirithvij to maintainers ``                               |
| [`7d75e3a6`](https://github.com/NixOS/nixpkgs/commit/7d75e3a61fe64c99c941df2c16a6a8d5c722787c) | `` discordchatexporter-cli: 2.47.2 -> 2.47.3 ``                                              |
| [`4a063a7a`](https://github.com/NixOS/nixpkgs/commit/4a063a7aee4a5305bc91a4dd85f882fdfd9b095a) | `` discordchatexporter-desktop: add phanirithvij to maintainers ``                           |
| [`7bec7ed4`](https://github.com/NixOS/nixpkgs/commit/7bec7ed4a8d57e066eb40f65ab44ba8c1052ca06) | `` discordchatexporter-desktop: 2.44.2 -> 2.47.3 ``                                          |
| [`f67b1a58`](https://github.com/NixOS/nixpkgs/commit/f67b1a58facec3b6665eae051f53140e04de9e37) | `` nmap-formatter: 3.1.3 -> 3.1.4 ``                                                         |
| [`691846b5`](https://github.com/NixOS/nixpkgs/commit/691846b598e37342cac6f6235cf5114114a5e365) | `` sherlock: fix build ``                                                                    |
| [`25e16345`](https://github.com/NixOS/nixpkgs/commit/25e163457f28b4a7b2e149de44c17ec1f618e610) | `` mlib: 0.8.0 -> 0.8.2 ``                                                                   |
| [`4811eae7`](https://github.com/NixOS/nixpkgs/commit/4811eae77f67a1fd76afc0f53aec039c71c9f2ac) | `` python3Packages.victron-mqtt: 2026.6.8 -> 2026.7.2 ``                                     |
| [`4025d0af`](https://github.com/NixOS/nixpkgs/commit/4025d0affd21bf5d801aef3c0ffdac1f0f92f397) | `` zashboard: 3.12.0 -> 3.14.0 ``                                                            |
| [`669c40d2`](https://github.com/NixOS/nixpkgs/commit/669c40d237423f48694605baac4ddf106f7e1a61) | `` emacsPackages.copilot: 0.6.0 -> 0.9.0 ``                                                  |
| [`fb2678cc`](https://github.com/NixOS/nixpkgs/commit/fb2678cc619077bf8996f04be5cad928adae330d) | `` terraform-providers.oracle_oci: 8.20.0 -> 8.22.0 ``                                       |
| [`bf0349bd`](https://github.com/NixOS/nixpkgs/commit/bf0349bdf8ab9255f25b7d3edb1914777d111dea) | `` kanata: download crate via CDN instead of API in updateScript ``                          |
| [`2d399183`](https://github.com/NixOS/nixpkgs/commit/2d39918345fb02dc2095957242bc6cf61c74df55) | `` limine-full: 12.4.0 -> 12.4.1 ``                                                          |
| [`7881b2b5`](https://github.com/NixOS/nixpkgs/commit/7881b2b5bc6886aec6e99522e99266e3862dec5b) | `` bs-manager.depotdownloader: 2.7.4-unstable-2024-12-01 -> 3.4.0-unstable-2026-05-14 ``     |
| [`24908150`](https://github.com/NixOS/nixpkgs/commit/2490815008d92b3acd76600b94b806161954f2b1) | `` postgresqlPackages.pg-gvm: 22.6.17 -> 22.6.18 ``                                          |
| [`151e98a0`](https://github.com/NixOS/nixpkgs/commit/151e98a0d967d5cdd891c49a6b4a3938d2a376f0) | `` rufin: 0.7.13 -> 0.8.0 ``                                                                 |
| [`470e7091`](https://github.com/NixOS/nixpkgs/commit/470e70919c91ce00f921494d50c4292299034e82) | `` frigate: use overrideScope ``                                                             |
| [`78465bd7`](https://github.com/NixOS/nixpkgs/commit/78465bd72e541008ec4badb774b24e51382f4f82) | `` terraform-providers.venafi_venafi: 0.24.0 -> 0.24.1 ``                                    |
| [`3f877fce`](https://github.com/NixOS/nixpkgs/commit/3f877fce06dc8638f3e5bbdfb35d472df2f72499) | `` python3Packages.py-nymta: unpin gtfs-realtime-bindings ``                                 |
| [`7740325d`](https://github.com/NixOS/nixpkgs/commit/7740325d623c41f6406f0e0e34e73f09cad5ad59) | `` tofu-ls: 0.5.1 -> 0.5.3 ``                                                                |
| [`d8f7f509`](https://github.com/NixOS/nixpkgs/commit/d8f7f50928e6bdacb7b2b8b818e0645a910f0276) | `` python3Packages.msgraph-sdk: 1.58.0 -> 1.59.0 ``                                          |
| [`32b6e195`](https://github.com/NixOS/nixpkgs/commit/32b6e195a6d6e2c0558c231a8565466f8afffa4f) | `` python3Packages.pyhomee: 1.4.1 -> 1.4.2 ``                                                |
| [`510e7f04`](https://github.com/NixOS/nixpkgs/commit/510e7f041f1239b8026d103380137f2e6e5b87f7) | `` python3Packages.frictionless: 5.18.1 -> 5.19.0 ``                                         |
| [`899d0917`](https://github.com/NixOS/nixpkgs/commit/899d0917f8c16f9d9715f50cee6a038116c39951) | `` google-chrome: 150.0.7871.100 -> 150.0.7871.114 ``                                        |
| [`6afe1454`](https://github.com/NixOS/nixpkgs/commit/6afe145494e34b222281b14de32705d849efd0a5) | `` python3Packages.kivy-garden: unbreak ``                                                   |
| [`1275fe95`](https://github.com/NixOS/nixpkgs/commit/1275fe9529ae8fd3073ef8cdf6a46c6666e94f4c) | `` cosmic-protocols: 0-unstable-2026-06-25 -> 0-unstable-2026-07-10 ``                       |
| [`47a73ac4`](https://github.com/NixOS/nixpkgs/commit/47a73ac4c3ccd7bf246efcdbe8ca779cbacae55d) | `` ecspresso: update ldflags for version embedding ``                                        |
| [`28999cb6`](https://github.com/NixOS/nixpkgs/commit/28999cb6b0b3c64874df7f26a9d9eda63a0316d2) | `` ecspresso: 2.8.4 -> 2.8.5 ``                                                              |
| [`99e90fc2`](https://github.com/NixOS/nixpkgs/commit/99e90fc2817d3393477baee5144dec5f673ce973) | `` edhm-ui: 3.0.67 -> 3.0.69 ``                                                              |
| [`1284d541`](https://github.com/NixOS/nixpkgs/commit/1284d54181f07ecce9ddb109371d225ae34c9da8) | `` python3Packages.types-tqdm: 4.67.3.20260303 -> 4.68.0.20260608 ``                         |
| [`f9e5b26e`](https://github.com/NixOS/nixpkgs/commit/f9e5b26e23aded0711c8253bea2511d9065029c9) | `` prowler: 5.33.0 -> 5.33.1 ``                                                              |
| [`f226ef25`](https://github.com/NixOS/nixpkgs/commit/f226ef25758c333f8a144545bbe97a6c4f18222a) | `` lintspec: 0.17.0 -> 0.18.0 ``                                                             |
| [`80d63dc5`](https://github.com/NixOS/nixpkgs/commit/80d63dc5743a047cf3c07a725bce92bba55f5118) | `` python3Packages.restrictedpython: 8.1 -> 8.4 ``                                           |
| [`165106e1`](https://github.com/NixOS/nixpkgs/commit/165106e1b0af59b4fffa3409a4f67e20e1979b2c) | `` libretro.bluemsx: 0-unstable-2026-06-26 -> 0-unstable-2026-07-04 ``                       |
| [`6228557c`](https://github.com/NixOS/nixpkgs/commit/6228557cf356df2fd742564fb10c4c701ef8b995) | `` terraform-providers.cyrilgdn_postgresql: 1.26.0 -> 1.27.0 ``                              |
| [`d31a6a56`](https://github.com/NixOS/nixpkgs/commit/d31a6a56f2b7212394bc2b7797f90fc3528c1028) | `` pandora-launcher-unwrapped: 5.2.2 -> 5.3.0 ``                                             |
| [`9f13e453`](https://github.com/NixOS/nixpkgs/commit/9f13e45303c8465b156155ca7e306dcb9ce56f30) | `` ory: 1.3.0 -> 1.3.1 ``                                                                    |
| [`2ede3c9d`](https://github.com/NixOS/nixpkgs/commit/2ede3c9db583e5451461b7d2d64af86e01fb412c) | `` beamPackages.expert: 0.1.5 -> 0.1.6 ``                                                    |
| [`49c7bba2`](https://github.com/NixOS/nixpkgs/commit/49c7bba2b61e72ed0fd3366cbccf4e5109f1ad0e) | `` beamPackages.hex: 2.5.0 -> 2.5.1 ``                                                       |
| [`9ec425bc`](https://github.com/NixOS/nixpkgs/commit/9ec425bc44f1eecc502522cf822b4bfd47e27c1f) | `` bruno: 3.5.0 -> 3.5.1 ``                                                                  |
| [`59395418`](https://github.com/NixOS/nixpkgs/commit/59395418b0c067afb0349784cf90d76c872ef9d4) | `` nixos/music-assistant: use go-librespot for spotify_connect ``                            |
| [`75d96b8f`](https://github.com/NixOS/nixpkgs/commit/75d96b8f258f2ce2441cade70afc4d206a0416e4) | `` music-assistant: 2.9.4 -> 2.9.6 ``                                                        |
| [`51519886`](https://github.com/NixOS/nixpkgs/commit/5151988682746c61f11a9909ea81ae95ba834ed1) | `` tui-journal: 0.16.1 -> 0.17.0 ``                                                          |
| [`cf224c5c`](https://github.com/NixOS/nixpkgs/commit/cf224c5c4628cdac3b04de8708f9dfa4d64562b5) | `` python3Packages.markdownify: 1.2.2 -> 1.2.3 ``                                            |
| [`84c6bf67`](https://github.com/NixOS/nixpkgs/commit/84c6bf6777aaab66a60d8e3d2cb3dc5fba598aa2) | `` slint-viewer: add required runtime dependencies ``                                        |
| [`ac0d2bb8`](https://github.com/NixOS/nixpkgs/commit/ac0d2bb8ca5834fbb6ce0fd13e57cc18c80c51c2) | `` python3Packages.sense-energy: 0.14.1 -> 0.14.2 ``                                         |
| [`aae4936e`](https://github.com/NixOS/nixpkgs/commit/aae4936e07347062039621483c8fd0b4382ae16c) | `` lib/services: add reload support for service management ``                                |
| [`03deb31b`](https://github.com/NixOS/nixpkgs/commit/03deb31b6bffea2f119bdec297672bd94413a907) | `` lib/services: add service readiness protocol support ``                                   |
| [`45b80cfb`](https://github.com/NixOS/nixpkgs/commit/45b80cfb9922ba89b1b60b2eb0ec649878e22649) | `` oo7-server: add option to use wrapped daemon ``                                           |
| [`791cee16`](https://github.com/NixOS/nixpkgs/commit/791cee16bd860cfc0f8a0ee192fede3e07a0a683) | `` nixos/oo7: add to release notes ``                                                        |
| [`d59ff0c9`](https://github.com/NixOS/nixpkgs/commit/d59ff0c996a702e8352b7f0a4eb61992ff4e719f) | `` nixos/oo7: init ``                                                                        |
| [`a84b6a24`](https://github.com/NixOS/nixpkgs/commit/a84b6a24af4461096a66c7cf44f058144fd85d12) | `` hcom: 0.7.22 -> 0.7.23 ``                                                                 |
| [`55a81846`](https://github.com/NixOS/nixpkgs/commit/55a81846f1d30ace9a0b7d6b0e231fe4267d312b) | `` zennotes-desktop: 2.10.0 -> 2.12.0 ``                                                     |
| [`bd630414`](https://github.com/NixOS/nixpkgs/commit/bd630414b131db548ed9d1e6772d1ee98a6f3b92) | `` python3Packages.wokkel: fix build ``                                                      |
| [`f2415eb3`](https://github.com/NixOS/nixpkgs/commit/f2415eb338bab69f23d283035231e2191fc76588) | `` home-assistant-custom-components.pi-hole-v6: 1.18.0 -> 1.19.0 ``                          |
| [`98aa7b61`](https://github.com/NixOS/nixpkgs/commit/98aa7b619e5017509c6a2902a45036614cda1b49) | `` nezha-theme-user: 2.3.1 -> 2.4.0 ``                                                       |
| [`a8da7744`](https://github.com/NixOS/nixpkgs/commit/a8da77449e160dc44039cccd34edbd106dddae4f) | `` python3Packages.sqlalchemy-continuum: 1.6.0 -> 1.7.0 ``                                   |
| [`b112b109`](https://github.com/NixOS/nixpkgs/commit/b112b109afbba8cab9d0b1a513160453d26ac913) | `` python3Packages.icalendar: fix build failure for python3.12 ``                            |
| [`25da7bc7`](https://github.com/NixOS/nixpkgs/commit/25da7bc761700d53fc353f248085d87ae6fd04b7) | `` runme: 3.16.17 -> 3.17.1 ``                                                               |
| [`b03a9037`](https://github.com/NixOS/nixpkgs/commit/b03a90375fb5874f4960c8bf9b98a409f776e550) | `` kdePackages: Frameworks 6.27 -> 6.28 ``                                                   |
| [`651e439f`](https://github.com/NixOS/nixpkgs/commit/651e439f9d9efc27afbc43112728943bcb51b5f0) | `` immichframe: 1.0.33.0 -> 1.0.35.0 ``                                                      |
| [`daf7a2e8`](https://github.com/NixOS/nixpkgs/commit/daf7a2e86f12151acb5f6221e00af207e8d2091f) | `` immichframe: refactor into one derivation ``                                              |
| [`74701dc4`](https://github.com/NixOS/nixpkgs/commit/74701dc4dbcfb3c49082709ded5b28859cdce33d) | `` home-assistant-custom-components.frigidaire: 0.1.22 -> 0.1.30 ``                          |
| [`9d0420a4`](https://github.com/NixOS/nixpkgs/commit/9d0420a484332a4197d15d561c980ea8597b9248) | `` slint-viewer: 1.17.0 -> 1.17.1 ``                                                         |
| [`0bfc1a44`](https://github.com/NixOS/nixpkgs/commit/0bfc1a440eb4c29679a48f08c7e093aa16d33fc3) | `` maintainers: update VZstless github username ``                                           |
| [`5915a78b`](https://github.com/NixOS/nixpkgs/commit/5915a78b7c236e9b546466fed2f7e358c6eaf2e4) | `` coroot: 1.23.2 -> 1.23.3 ``                                                               |
| [`c2a978b3`](https://github.com/NixOS/nixpkgs/commit/c2a978b39121b6172845216f697c2a18043729b2) | `` streamlink: fix build ``                                                                  |
| [`06a69e06`](https://github.com/NixOS/nixpkgs/commit/06a69e06ce36d388cd6e9ed34362f4b5a379ba35) | `` python3Packages.coiled: 1.134.1 -> 1.135.1 ``                                             |
| [`efb435a0`](https://github.com/NixOS/nixpkgs/commit/efb435a0b25dcd3c51df85d6c1300bff79e99afd) | `` python3Packages.yattag: enable tests ``                                                   |
| [`dbb519e9`](https://github.com/NixOS/nixpkgs/commit/dbb519e93ab7eb55e838b8505c2ddaf1407a884d) | `` gitfetch: 1.3.3 -> 1.4.0 ``                                                               |
| [`4bc0886d`](https://github.com/NixOS/nixpkgs/commit/4bc0886d13d2e9ef8304a9bb56d3e1087da85a09) | `` chisel: 1.11.7 -> 1.11.8 ``                                                               |
| [`3063968e`](https://github.com/NixOS/nixpkgs/commit/3063968e161c2d0638147e8d2484833b70df33ea) | `` nixos/matrix-authentication-service: fix loading of extraConfigFiles ``                   |
| [`1992c907`](https://github.com/NixOS/nixpkgs/commit/1992c9070d65d8cfd8a2a79ef38785953aa11943) | `` tetex: migrate to by-name ``                                                              |
| [`c1c08336`](https://github.com/NixOS/nixpkgs/commit/c1c08336a2639ec2d3adf84bd3f6779df9b07953) | `` non: migrate to by-name ``                                                                |
| [`0538256f`](https://github.com/NixOS/nixpkgs/commit/0538256f8652d326a828d6367122c1ffc31069b4) | `` atuin: 18.16.1 -> 18.17.0 ``                                                              |
| [`c5b841c2`](https://github.com/NixOS/nixpkgs/commit/c5b841c29de88504b1f5ed9f38c1c95fbc226886) | `` flyctl: 0.4.63 -> 0.4.69 ``                                                               |
| [`2e542858`](https://github.com/NixOS/nixpkgs/commit/2e542858194b9467d500f2af1ebfe171b951a7e3) | `` k8sgpt: 0.4.35 -> 0.4.36 ``                                                               |
| [`9bf7f6da`](https://github.com/NixOS/nixpkgs/commit/9bf7f6da486d9bdffe5e11427d46a2f30e5924e7) | `` lockbook-desktop: 26.6.22 -> 26.7.4 ``                                                    |
| [`8d0855c0`](https://github.com/NixOS/nixpkgs/commit/8d0855c02d95bd8c5a7c072d1d22e1a2fd233289) | `` azimuth: 1.0.3 -> 1.0.4 ``                                                                |
| [`0882535f`](https://github.com/NixOS/nixpkgs/commit/0882535f660ad2785840b9fcdfcd6f9869fbe1a9) | `` jackett: 0.24.2151 -> 0.24.2200 ``                                                        |
| [`c045eb88`](https://github.com/NixOS/nixpkgs/commit/c045eb888beaac7d024773b755329cc1e28007e8) | `` python3Packages.libmobility: 1.1.2 -> 1.2.0 ``                                            |
| [`1c979151`](https://github.com/NixOS/nixpkgs/commit/1c979151db287c14ff2454b63e7afc45360a5ecc) | `` m1n1: expose rustPackages ``                                                              |
| [`f37e759d`](https://github.com/NixOS/nixpkgs/commit/f37e759de7556a2275ba201e782c46fd0aba733a) | `` forgejo-runner: 12.12.0 -> 12.13.0 ``                                                     |
| [`37d95596`](https://github.com/NixOS/nixpkgs/commit/37d95596c220e8393f3ea9995ef6ae542f7da942) | `` python3Packages.langchain-mistralai: 1.1.5 -> 1.1.6 ``                                    |
| [`6a2d236b`](https://github.com/NixOS/nixpkgs/commit/6a2d236bb7bbff9e7b2fe960d21a73b704f32c40) | `` oelint-adv: 9.9.1 -> 9.9.2 ``                                                             |
| [`6eba3f4e`](https://github.com/NixOS/nixpkgs/commit/6eba3f4e342e7a83b2d532b06a15d1e70831406c) | `` kin-openapi: 0.140.0 -> 0.141.0 ``                                                        |
| [`3f000cb5`](https://github.com/NixOS/nixpkgs/commit/3f000cb56494275a8f6632f45f87bf4836b378ee) | `` gforth: 0.7.9_20260610 -> 0.7.9_20260708 ``                                               |
| [`5c09a284`](https://github.com/NixOS/nixpkgs/commit/5c09a284ca0cdc6891c5a3ccb10049f48424a851) | `` python3Packages.zha-quirks: 2.1.0 -> 2.1.1 ``                                             |
| [`d2260f0c`](https://github.com/NixOS/nixpkgs/commit/d2260f0cd7ff762f23c6e7ff87ce9be41f074bd7) | `` python3Packages.sphinx-llms-txt: init at 0.7.1 ``                                         |
| [`eb479920`](https://github.com/NixOS/nixpkgs/commit/eb479920302c92782e3ea4dab9673c15010bfbd2) | `` python3Packages.smbprotocol: 1.16.1 -> 1.17.0 ``                                          |
| [`3023d6b1`](https://github.com/NixOS/nixpkgs/commit/3023d6b101f065eb8111cfa32a1485a347977090) | `` ggml: 0.15.3 -> 0.16.0 ``                                                                 |
| [`eea90ecd`](https://github.com/NixOS/nixpkgs/commit/eea90ecde31284fde2556cd05a010e2f395407cb) | `` wootility: 5.3.1 -> 5.3.2 ``                                                              |
| [`e5ec0c56`](https://github.com/NixOS/nixpkgs/commit/e5ec0c56b76c9055faabdbf2567565cbbba3e9b2) | `` xan: 0.59.0 -> 0.60.0 ``                                                                  |
| [`c01e6d03`](https://github.com/NixOS/nixpkgs/commit/c01e6d03818c6fd61d2d77d3618fd9b2c8d7bb12) | `` worktrunk: 0.61.0 -> 0.66.0 ``                                                            |
| [`dc5eccaa`](https://github.com/NixOS/nixpkgs/commit/dc5eccaaeada7995d3b817e7d7c3bf3ab30b9b20) | `` opencode{,-desktop}: 1.17.15 -> 1.17.18 ``                                                |
| [`7ca8f6a3`](https://github.com/NixOS/nixpkgs/commit/7ca8f6a31d4c58d3202d7112557848af81f5917d) | `` databricks-cli: 1.2.1 -> 1.7.0 ``                                                         |
| [`6a30e6ea`](https://github.com/NixOS/nixpkgs/commit/6a30e6ea5df117da7dd3ff2d616f60017db97b4d) | `` home-assistant-custom-lovelace-modules.multiple-entity-row: 4.6.1 -> 4.7.0 ``             |
| [`d26cf5ce`](https://github.com/NixOS/nixpkgs/commit/d26cf5ced37effbf6fca3f1570903891b2e32fbc) | `` proton-pass-cli: 2.2.2 -> 2.2.3 ``                                                        |
| [`4fca9750`](https://github.com/NixOS/nixpkgs/commit/4fca975023f7044687ceaf3df1b4579a133a7c91) | `` pkgs/top-level/aliases.nix: Fix aliases introduced with lomiri-qt6 ``                     |
| [`bbb77b5d`](https://github.com/NixOS/nixpkgs/commit/bbb77b5d1ae0ea2ca4b35910b93f0180b797731b) | `` python3Packages.pueblo: 0.0.18 -> 0.0.19 ``                                               |
| [`b6807437`](https://github.com/NixOS/nixpkgs/commit/b6807437b8c622dc56a8db4415a5471a46c0711e) | `` nvitop: 1.7.0 -> 1.7.1 ``                                                                 |
| [`5e7dc102`](https://github.com/NixOS/nixpkgs/commit/5e7dc102345608a1920ca16dfc04148bd5bbdfe2) | `` bottom: 0.14.3 -> 0.14.4 ``                                                               |
| [`06081dce`](https://github.com/NixOS/nixpkgs/commit/06081dce2708fe91c8a69081e4b9da5b811f6899) | `` tsx: update homepage ``                                                                   |
| [`e5bd7c43`](https://github.com/NixOS/nixpkgs/commit/e5bd7c436c887cd7db719d9b3490ec03802c23f2) | `` alt-tab-macos: build from source ``                                                       |
| [`133dae2a`](https://github.com/NixOS/nixpkgs/commit/133dae2a9eb9b131541daf7c83aa37a3d98ed96c) | `` kalamine: adopt ``                                                                        |
| [`58b83392`](https://github.com/NixOS/nixpkgs/commit/58b83392e911e9b28eb88bd0e8da928b8514c1e5) | `` .github: Bump actions/labeler from 6.1.0 to 6.2.0 ``                                      |
| [`53c53d5d`](https://github.com/NixOS/nixpkgs/commit/53c53d5d5b7e3992614b9de4509a73e2e539f93e) | `` .github: Bump cachix/install-nix-action from 31.10.6 to 31.10.7 ``                        |
| [`99820401`](https://github.com/NixOS/nixpkgs/commit/998204016ee8003a264fd45e5ea37e9cbe286cfd) | `` just-lsp: 0.4.7 -> 0.4.8 ``                                                               |
| [`2e3b2946`](https://github.com/NixOS/nixpkgs/commit/2e3b29465e1b6e97ea5abf6e095df06473f9d6a6) | `` chameleon-cli: 2.1.0-unstable-2026-05-08 -> 2.2.0-unstable-2026-07-04 ``                  |
| [`da9297c8`](https://github.com/NixOS/nixpkgs/commit/da9297c8fd0bd42344e866fe18c5b77f93829671) | `` mediaelch: backport TMDb duplicate include_adult search fix ``                            |
| [`658bf820`](https://github.com/NixOS/nixpkgs/commit/658bf820ccf7d18ca72a62bf15d8150a4c250485) | `` nanosvg: 0-unstable-2026-05-18 -> 0-unstable-2026-07-10 ``                                |
| [`f289bbc0`](https://github.com/NixOS/nixpkgs/commit/f289bbc036f91f966de3b16faa7b70365d0cc6a0) | `` emscripten: 5.0.7 -> 6.0.2 ``                                                             |
| [`34779334`](https://github.com/NixOS/nixpkgs/commit/34779334177d914a4d814811f043d7fa3585e03f) | `` pdk-ciel: 2.6.0 -> 2.6.1 ``                                                               |
| [`25ec64a3`](https://github.com/NixOS/nixpkgs/commit/25ec64a34557b81191cd87b502bd15c201ece652) | `` usage: 3.5.3 -> 3.5.4 ``                                                                  |
| [`1207148e`](https://github.com/NixOS/nixpkgs/commit/1207148e8974b25ea69f171e38e3f1d3c91c99bd) | `` python3Packages.types-decorator: migrate to finalAttrs ``                                 |
| [`7b26b7d7`](https://github.com/NixOS/nixpkgs/commit/7b26b7d72fb9a9e16a3c6db3591867f0ac3a9206) | `` python3Packages.teslemetry-stream: 0.9.0 -> 0.9.1 ``                                      |
| [`5497312a`](https://github.com/NixOS/nixpkgs/commit/5497312aa609a4ad015094a2c014318d6e90928d) | `` python3Packages.tencentcloud-sdk-python: 3.1.129 -> 3.1.130 ``                            |
| [`0492bf83`](https://github.com/NixOS/nixpkgs/commit/0492bf83450901ebd12327f1895e8629e5d5bd3c) | `` python3Packages.boto3-stubs: 1.43.44 -> 1.43.45 ``                                        |
| [`5605ca2e`](https://github.com/NixOS/nixpkgs/commit/5605ca2e01b08c06fc7bd563bcf40355cf560e40) | `` python3Packages.mypy-boto3-synthetics: 1.43.33 -> 1.43.45 ``                              |
| [`4fd2a2dd`](https://github.com/NixOS/nixpkgs/commit/4fd2a2dd20e568dd793d69a718f82de0c18a3caa) | `` python3Packages.mypy-boto3-ivs: 1.43.23 -> 1.43.45 ``                                     |
| [`af4fb0c4`](https://github.com/NixOS/nixpkgs/commit/af4fb0c4b03faf1721164323fcb8535a4e52861f) | `` python3Packages.mypy-boto3-guardduty: 1.43.35 -> 1.43.45 ``                               |
| [`c0b3f333`](https://github.com/NixOS/nixpkgs/commit/c0b3f33344cf79ced02c03388ce8427798532c94) | `` python3Packages.mypy-boto3-ec2: 1.43.43 -> 1.43.45 ``                                     |
| [`bf0c2178`](https://github.com/NixOS/nixpkgs/commit/bf0c2178f2222cf764a8ebd2c121713ceba61120) | `` python3Packages.mypy-boto3-connect: 1.43.42 -> 1.43.45 ``                                 |
| [`d174433e`](https://github.com/NixOS/nixpkgs/commit/d174433e53cd0b7013f126320263e7ebeaaca604) | `` python3Packages.boto3-stubs: 1.43.42 -> 1.43.44 ``                                        |
| [`619d49e5`](https://github.com/NixOS/nixpkgs/commit/619d49e53072d58cb0ee770cdba9088158a86c6f) | `` python3Packages.mypy-boto3-iotwireless: 1.43.0 -> 1.43.43 ``                              |
| [`664bff96`](https://github.com/NixOS/nixpkgs/commit/664bff96eecb59a6cdef8cd825511006db4f5765) | `` python3Packages.mypy-boto3-ecs: 1.43.38 -> 1.43.43 ``                                     |
| [`a0e38285`](https://github.com/NixOS/nixpkgs/commit/a0e382853f8f185dda45cadb0c4942530d837ecf) | `` python3Packages.mypy-boto3-ec2: 1.43.42 -> 1.43.43 ``                                     |
| [`e11d4e3d`](https://github.com/NixOS/nixpkgs/commit/e11d4e3d73242e01c928d83f23872c9b8986efd7) | `` python3Packages.mypy-boto3-appconfig: 1.43.37 -> 1.43.43 ``                               |
| [`92431d18`](https://github.com/NixOS/nixpkgs/commit/92431d18ad60d576853f3eb415761ca515c7eaf7) | `` python3Packages.boto3-stubs: 1.43.41 -> 1.43.42 ``                                        |
| [`eac163c7`](https://github.com/NixOS/nixpkgs/commit/eac163c7093f62d31f8feb590108ea2a68d7b496) | `` python3Packages.mypy-boto3-ssm: 1.43.0 -> 1.43.42 ``                                      |
| [`4fabd987`](https://github.com/NixOS/nixpkgs/commit/4fabd9872b6e337eceefee00c345ebf0972e5d23) | `` python3Packages.mypy-boto3-securityhub: 1.43.5 -> 1.43.42 ``                              |
| [`4c60255f`](https://github.com/NixOS/nixpkgs/commit/4c60255ff1e1c3795cee72e921f6f18e21faa7ab) | `` python3Packages.mypy-boto3-meteringmarketplace: 1.43.39 -> 1.43.42 ``                     |
| [`95e64252`](https://github.com/NixOS/nixpkgs/commit/95e64252af247957957d9aab111a9f1158e04bfc) | `` python3Packages.mypy-boto3-marketplace-catalog: 1.43.0 -> 1.43.42 ``                      |
| [`665a257d`](https://github.com/NixOS/nixpkgs/commit/665a257dfb661d96c85dd877b7b84175f16ac4c4) | `` python3Packages.mypy-boto3-lambda: 1.43.37 -> 1.43.42 ``                                  |
| [`5fb975dc`](https://github.com/NixOS/nixpkgs/commit/5fb975dcfb629ee942f46e87b215f3848b5b13d8) | `` python3Packages.mypy-boto3-inspector2: 1.43.22 -> 1.43.42 ``                              |
| [`d3e54c45`](https://github.com/NixOS/nixpkgs/commit/d3e54c45ae8c636b2ba376be7ed4b163cd1f21ca) | `` python3Packages.mypy-boto3-ec2: 1.43.39 -> 1.43.42 ``                                     |
| [`9012fdbb`](https://github.com/NixOS/nixpkgs/commit/9012fdbb9cbc1b8cfa877d26beef438677923651) | `` python3Packages.mypy-boto3-connect: 1.43.39 -> 1.43.42 ``                                 |
| [`2fa814f1`](https://github.com/NixOS/nixpkgs/commit/2fa814f1af4f41d1774412418d08085762887563) | `` python3Packages.mypy-boto3-config: 1.43.40 -> 1.43.42 ``                                  |
| [`36f4fbe4`](https://github.com/NixOS/nixpkgs/commit/36f4fbe4c5bc49269356ba9263b41a31777cb2c9) | `` ghostfolio: 3.18.0 -> 3.22.0 ``                                                           |
| [`4e6c396f`](https://github.com/NixOS/nixpkgs/commit/4e6c396fbc0974adf2d938594afe665df15999fd) | `` codex: 0.142.5 -> 0.144.1 ``                                                              |
| [`a59eacb1`](https://github.com/NixOS/nixpkgs/commit/a59eacb193b52c8c9f20a49cdc2f1c3c52cf5726) | `` vscode-extensions.mshr-h.veriloghdl: 1.27.4 -> 1.28.1 ``                                  |
| [`3cd74142`](https://github.com/NixOS/nixpkgs/commit/3cd74142fbf0f65b98ac96309e59d9608c4a9368) | `` prometheus-klipper-exporter: 0.15.0 -> 0.16.0 ``                                          |
| [`ef1a83ae`](https://github.com/NixOS/nixpkgs/commit/ef1a83ae4b2b9cf14637616d58c3c09552b456fc) | `` python3Packages.hier-config: 3.6.0 -> 3.6.1 ``                                            |
| [`30149ad5`](https://github.com/NixOS/nixpkgs/commit/30149ad5e70667fc3593ac3839e167c50a2e7910) | `` python3Packages.llama-cloud: 2.10.0 -> 2.11.0 ``                                          |
| [`5745b73b`](https://github.com/NixOS/nixpkgs/commit/5745b73bf2c9dbafbe6277f894dc3cd68a0d9cbb) | `` wire-desktop: fix eval on unsupported systems ``                                          |
| [`f3503484`](https://github.com/NixOS/nixpkgs/commit/f350348488197c7d3319983afca4ce2043918725) | `` plover_5: 5.3.0 -> 5.4.0 ``                                                               |
| [`ea1628f4`](https://github.com/NixOS/nixpkgs/commit/ea1628f4e77d2b4431cc79f79e98a665e56db63b) | `` actions/checkout: retry transient API failures ``                                         |
| [`a11e07c0`](https://github.com/NixOS/nixpkgs/commit/a11e07c07ed1b31424a3cdfe8d49ce9c25639140) | `` vscode-extensions.shardulm94.trailing-spaces: 0.4.1 -> 0.4.4 ``                           |
| [`f99e3437`](https://github.com/NixOS/nixpkgs/commit/f99e34371714557d859a409343a6b93bbdf96ef0) | `` python3Packages.wtf-peewee: 3.1.0 -> 3.2.1 ``                                             |
| [`ff3f65e5`](https://github.com/NixOS/nixpkgs/commit/ff3f65e52f449eafebd04d4b8bd243a4d2a745a0) | `` python3Packages.reolink-aio: 0.21.3 -> 0.21.4 ``                                          |
| [`68bf5c90`](https://github.com/NixOS/nixpkgs/commit/68bf5c90e7c8d388fb7f5ac930cc9b2ca0d81448) | `` super-productivity: 18.12.1 -> 18.13.1 ``                                                 |
| [`b4b5e36e`](https://github.com/NixOS/nixpkgs/commit/b4b5e36e1b8df5f504f6866ad5b76ce1ae477c26) | `` kyverno: 1.18.1 -> 1.18.2 ``                                                              |
| [`8fb47769`](https://github.com/NixOS/nixpkgs/commit/8fb47769e0e49415b282a2c4ba8f289e0516d116) | `` unifi: 10.4.57 -> 10.5.54 ``                                                              |
| [`872e6515`](https://github.com/NixOS/nixpkgs/commit/872e65150c0b062e327467b00ada5a56f041148f) | `` python3Packages.types-ipaddress: modernize ``                                             |
| [`101e1a43`](https://github.com/NixOS/nixpkgs/commit/101e1a43d8b3ec57a6e873db9b46fbad8d4d0b1f) | `` python3Packages.types-ipaddress: migrate to pyproject ``                                  |
| [`c9873027`](https://github.com/NixOS/nixpkgs/commit/c9873027f846fb52261a414951f0bf7d149fdfc7) | `` fscan: 2.1.3 -> 2.2.0 ``                                                                  |
| [`e3a1e353`](https://github.com/NixOS/nixpkgs/commit/e3a1e3531c0248da14001342538f66f94b8061d9) | `` postgresqlPackages.plpgsql_check: 2.9.1 -> 2.9.3 ``                                       |
| [`73acc2f7`](https://github.com/NixOS/nixpkgs/commit/73acc2f7a1bcf458490f8df35ac1058690c2c876) | `` node-gyp: 13.0.0 -> 13.0.1 ``                                                             |
| [`0d8a45a5`](https://github.com/NixOS/nixpkgs/commit/0d8a45a591f8717052615dbd8a5384b4a26a00cd) | `` flux9s: 0.10.2 -> 0.11.0 ``                                                               |
| [`06ade519`](https://github.com/NixOS/nixpkgs/commit/06ade5193fd517fb58491054679fba4a9d3884db) | `` git-machete: 3.44.0 -> 3.44.1 ``                                                          |
| [`5ce3edd3`](https://github.com/NixOS/nixpkgs/commit/5ce3edd3d2f31e0e7ca7c1ab4f81d3f621f7e398) | `` terraform-providers.hashicorp_kubernetes: 3.2.0 -> 3.2.1 ``                               |
| [`c5fedb24`](https://github.com/NixOS/nixpkgs/commit/c5fedb244cd738555d8af8ac1bd9e2bd86704d20) | `` vscode-extensions.anthropic.claude-code: 2.1.205 -> 2.1.206 ``                            |
| [`7fb694b3`](https://github.com/NixOS/nixpkgs/commit/7fb694b30a1edae368bb0a0710c561af8970924b) | `` claude-code: 2.1.205 -> 2.1.206 ``                                                        |
| [`5dcaf607`](https://github.com/NixOS/nixpkgs/commit/5dcaf60753d50f9d90237d8944d760f5d7ec48f2) | `` wezterm: 0-unstable-2026-07-05 -> 0-unstable-2026-07-07 ``                                |
| [`543ba03f`](https://github.com/NixOS/nixpkgs/commit/543ba03fed5bc945da716bfd816386668386296d) | `` nixosTests.pdfding: fix on aarch64-linux ``                                               |
| [`e841194c`](https://github.com/NixOS/nixpkgs/commit/e841194c9ef5f00696937dcf8c8f797586bfb752) | `` mxnet: enable strictDeps, __structuredAttrs ``                                            |
| [`a12b4bcd`](https://github.com/NixOS/nixpkgs/commit/a12b4bcd86ab62a9e857aa07cf2b9f1626691813) | `` emacs.pkgs.session-management-for-emacs: 2.2a -> 2.4b ``                                  |
| [`d40c9736`](https://github.com/NixOS/nixpkgs/commit/d40c97363d75bf22fc375a9e2405bfa0dee0e4c4) | `` emacs.pkgs.color-theme-solarized: remove ignoreCompilationError ``                        |
| [`19f097d6`](https://github.com/NixOS/nixpkgs/commit/19f097d60a64880edc00b57a0fa670350a4ac3ff) | `` emacs.pkgs.xr: remove ignoreCompilationError which is not needed now ``                   |
| [`0b7b877e`](https://github.com/NixOS/nixpkgs/commit/0b7b877e9afcdd7343ee3ec2d0b63c749ca433ae) | `` pam: add support for oo7 ``                                                               |
| [`c602ea66`](https://github.com/NixOS/nixpkgs/commit/c602ea66b9e645a11ef72438cae4efaa81fce914) | `` python3Packages.types-regex: 2026.2.28.20260301 -> 2026.6.28.20260630 ``                  |
| [`58ea998a`](https://github.com/NixOS/nixpkgs/commit/58ea998ae5835725700645f831a4656625a62e99) | `` mxnet: replace cudatoolkit ``                                                             |
| [`5c0a5484`](https://github.com/NixOS/nixpkgs/commit/5c0a54842e3b6318a9eb424d7e809ea50cab2483) | `` lmstudio: 0.4.18.1 -> 0.4.19.2 ``                                                         |
| [`656f072b`](https://github.com/NixOS/nixpkgs/commit/656f072b88e8f1c82b038265232bfade43ae8e97) | `` nixosTests.pdfding.s3-backup: fix test ``                                                 |
| [`7694f305`](https://github.com/NixOS/nixpkgs/commit/7694f305d4d9f0263961b00ccec6ed86859ee369) | `` pdfding: 1.9.0 -> 1.10.0 ``                                                               |
| [`ea4d8fcc`](https://github.com/NixOS/nixpkgs/commit/ea4d8fcc4ac4f5aaccfd2fde4a9f15c6f0e6478a) | `` seaweedfs: 4.38 -> 4.39 ``                                                                |
| [`56cdf6d9`](https://github.com/NixOS/nixpkgs/commit/56cdf6d9a5a299af46d789a9e4f033c24fe3a9ee) | `` vacuum-tube: 1.8.0 -> 1.8.1 ``                                                            |
| [`1d91fb67`](https://github.com/NixOS/nixpkgs/commit/1d91fb67ce09771a3f7263d377102666a963557e) | `` mailpit: 1.30.3 -> 1.30.4 ``                                                              |
| [`b90555f1`](https://github.com/NixOS/nixpkgs/commit/b90555f16e96acde16dc538d8861ca8af0d8cc2f) | `` python3Packages.aiogram: 3.29.0 -> 3.29.1 ``                                              |
| [`7540845f`](https://github.com/NixOS/nixpkgs/commit/7540845f5f8b1a6ade12bbf0245cb67809c29e81) | `` trufflehog: 3.95.8 -> 3.95.9 ``                                                           |
| [`6561c1d4`](https://github.com/NixOS/nixpkgs/commit/6561c1d4aeb61ea2fb08a0ccc60224a5e24e9342) | `` spire: 1.15.1 -> 1.15.2 ``                                                                |
| [`f9ed02a1`](https://github.com/NixOS/nixpkgs/commit/f9ed02a15640e192e87a87877970b880644d7429) | `` ttdl: 6.1.1 -> 6.2.1 ``                                                                   |
| [`3e1687ed`](https://github.com/NixOS/nixpkgs/commit/3e1687edfd7a856ccefd4118d990659e68ed1a06) | `` python3Packages.epaper-dithering: 5.0.7 -> 5.0.9 ``                                       |
| [`8360e002`](https://github.com/NixOS/nixpkgs/commit/8360e0024d1a350ce9d69a58e117029e5f2f6077) | `` phpstan: 2.2.3 -> 2.2.5 ``                                                                |
| [`d24c84d3`](https://github.com/NixOS/nixpkgs/commit/d24c84d35579af7c60362f8bd3389d26de1391ad) | `` pulumi-esc: 0.25.0 -> 0.26.0 ``                                                           |
| [`834624ed`](https://github.com/NixOS/nixpkgs/commit/834624ed0d71b4613991658391d0db0478bddde2) | `` shelfmark: 1.3.2 -> 1.3.3 ``                                                              |
| [`973a6a7c`](https://github.com/NixOS/nixpkgs/commit/973a6a7ca66cbb4d8094e24fa19b4321065543c7) | `` terraform-providers.newrelic_newrelic: 3.94.0 -> 3.94.3 ``                                |
| [`3ba262e9`](https://github.com/NixOS/nixpkgs/commit/3ba262e95b67b073e0fb63de72dc4354bb7ad356) | `` python3Packages.langchain-google-genai: 4.2.6 -> 4.2.7 ``                                 |
| [`c4c0fd0f`](https://github.com/NixOS/nixpkgs/commit/c4c0fd0f81db9ffc02c6af25304d93bed73876cf) | `` fluentd: 1.18.0 -> 1.19.3 ``                                                              |
| [`49823315`](https://github.com/NixOS/nixpkgs/commit/498233150d3cdd85de94ad92051fda56b2eaf3a7) | `` kubernetes-helm: 4.2.2 -> 4.2.3 ``                                                        |
| [`6d4e8472`](https://github.com/NixOS/nixpkgs/commit/6d4e84727f1b671a36b0db97b2d23fff8832f40c) | `` terraform-providers.opentelekomcloud_opentelekomcloud: 1.36.70 -> 1.37.1 ``               |
| [`82524770`](https://github.com/NixOS/nixpkgs/commit/825247703a0a06f5f7dbe486e2787eac21344ffa) | `` fence: 0.1.61 -> 0.1.62 ``                                                                |
| [`12030ff3`](https://github.com/NixOS/nixpkgs/commit/12030ff372319abc4e68adb14336f562ba721aa6) | `` python3Packages.pyzx: 0.10.3 -> 0.10.4 ``                                                 |
| [`5e96cb6f`](https://github.com/NixOS/nixpkgs/commit/5e96cb6f7427a3860d7e21c31b4a8034fa8f2d80) | `` avml: 0.19.0 -> 0.20.0 ``                                                                 |
| [`b9ffe81b`](https://github.com/NixOS/nixpkgs/commit/b9ffe81b919d376f2b379977ef49fc7ecc563b12) | `` cloudflare-dynamic-dns: 4.5.0 -> 4.5.1 ``                                                 |
| [`4b412d09`](https://github.com/NixOS/nixpkgs/commit/4b412d093a50b6e2a1613b9f912ce38138e2c63d) | `` govulncheck: 1.5.0 -> 1.6.0 ``                                                            |
| [`56f0fcea`](https://github.com/NixOS/nixpkgs/commit/56f0fceaef29f10bfbd80f3b68aaf7112eb272fe) | `` wayvnc: 0.10.0 -> 0.10.1 ``                                                               |
| [`3b60cb69`](https://github.com/NixOS/nixpkgs/commit/3b60cb6988be23b679dca1a04603948f298569bc) | `` kicad-testing: 10.0-2026-06-26 -> 10.0-2026-07-09 ``                                      |
| [`1d415647`](https://github.com/NixOS/nixpkgs/commit/1d415647fee52f051e1c9710abc8a6d7ac77ff85) | `` tageditor: 3.9.10 -> 3.9.11 ``                                                            |
| [`f4779305`](https://github.com/NixOS/nixpkgs/commit/f47793054bf2f2bec0740835df08f9f18f4b561a) | `` python3Packages.aiointercept: 0.1.8 -> 0.1.9 ``                                           |
| [`04e139aa`](https://github.com/NixOS/nixpkgs/commit/04e139aa4ade31516aa7b8e142b2edd8a0300933) | `` python3Packages.slixmpp: 1.16.0 -> 1.17.0 ``                                              |
| [`f4d05dda`](https://github.com/NixOS/nixpkgs/commit/f4d05ddae14c37880b8c45154f4aba4d41878cf0) | `` postfix: 3.11.4 -> 3.11.5 ``                                                              |
| [`33a37243`](https://github.com/NixOS/nixpkgs/commit/33a372431cda321bfb537a491daa2efff6034524) | `` flare-signal: 0.20.6 -> 0.21.0 ``                                                         |
| [`6100a7c7`](https://github.com/NixOS/nixpkgs/commit/6100a7c743fc30c31a931aeae857bae4f8421588) | `` python3Packages.heretic-llm: 1.2.0 -> 1.4.0 ``                                            |
| [`e67e863b`](https://github.com/NixOS/nixpkgs/commit/e67e863b42102e34696341103c1e25d10f05109f) | `` bentopdf: add passthru.updateScript ``                                                    |
| [`ce922106`](https://github.com/NixOS/nixpkgs/commit/ce922106ccb7d3b627d1c80426113221a62b5768) | `` bentopdf: 1.11.2 -> 2.8.6 ``                                                              |
| [`ad7acd6c`](https://github.com/NixOS/nixpkgs/commit/ad7acd6ce5f44265e668c4fa5901f79a76facbb8) | `` ytdl-sub: disable test_directory_exists ``                                                |
| [`012a2765`](https://github.com/NixOS/nixpkgs/commit/012a27656625e616a5378f3e8b2df9e4ecd60580) | `` oxygenfonts: Change source to archive from invent.kde.org ``                              |
| [`b0bdeb8c`](https://github.com/NixOS/nixpkgs/commit/b0bdeb8c416ea5b9879fd33e8920c822712e2d80) | `` oxygenfonts: migrate to installFonts hook ``                                              |
| [`fc0ca5c2`](https://github.com/NixOS/nixpkgs/commit/fc0ca5c24a297dbeed8ddea03b18a9b5752807dc) | `` oxygenfonts: add maintainer VarNepvius ``                                                 |
| [`0d6707b9`](https://github.com/NixOS/nixpkgs/commit/0d6707b9882020225a873b1269241d9e0e100731) | `` maintainers: add VarNepvius ``                                                            |
| [`85f65988`](https://github.com/NixOS/nixpkgs/commit/85f65988e8813c075a792f44182d9896620b13df) | `` copyparty: 1.20.17 -> 1.20.18 ``                                                          |
| [`8cb5c67c`](https://github.com/NixOS/nixpkgs/commit/8cb5c67c457908b6fa68916074bbc245c988c62b) | `` ipatool: 2.3.0 -> 2.3.1 ``                                                                |
| [`b307ffe2`](https://github.com/NixOS/nixpkgs/commit/b307ffe220fec523f2d13529d71466d55fbc356f) | `` python3Packages.msrplib: 0.21.0-unstable-2021-06-01 -> 0.21.0-unstable-2026-07-09 ``      |
| [`a1f58ea7`](https://github.com/NixOS/nixpkgs/commit/a1f58ea706bb26406818d14cb60aef666e36eca0) | `` present: use mistune_2 ``                                                                 |
| [`dc50ff40`](https://github.com/NixOS/nixpkgs/commit/dc50ff406feece7d76ad9c4d5e0e6a8a273a84df) | `` lektor: use mistune_2 ``                                                                  |
| [`9945d0ef`](https://github.com/NixOS/nixpkgs/commit/9945d0efaa265b9d172332b4a49af3042d575fc9) | `` python3Packages.mistune_2: init at 2.0.5 ``                                               |
| [`d3cc318c`](https://github.com/NixOS/nixpkgs/commit/d3cc318c7e99fd2d6c54686c9c15b00903c33b63) | `` home-assistant-custom-lovelace-modules.weather-radar-card: 3.7.1 -> 3.7.2 ``              |
| [`55da6e87`](https://github.com/NixOS/nixpkgs/commit/55da6e8768b98b03afa0edc029de76c39fba2bab) | `` python3Packages.pylacus: 1.24.4 -> 1.25.0 ``                                              |
| [`f73f96fe`](https://github.com/NixOS/nixpkgs/commit/f73f96fed50fe0b40e38a22f91344ec99523204c) | `` ungoogled-chromium: 150.0.7871.100-1 -> 150.0.7871.114-1 ``                               |
| [`5e43178d`](https://github.com/NixOS/nixpkgs/commit/5e43178d4be265a03a51a959c70d6d363d919512) | `` amp-cli: 0.0.1782851652-gfd0e56 -> 0.0.1783629102-g8185a2 ``                              |
| [`fe560ffd`](https://github.com/NixOS/nixpkgs/commit/fe560ffd0a034bf857164a8ebfd7460a0d589dc9) | `` cargo-deny: 0.19.9 -> 0.20.2 ``                                                           |
| [`df5c1e0f`](https://github.com/NixOS/nixpkgs/commit/df5c1e0f57c02a843df63c53ad7f77bced6b667e) | `` cpp-utilities: 5.34.1 -> 5.34.2 ``                                                        |
| [`6436f1f7`](https://github.com/NixOS/nixpkgs/commit/6436f1f78e63043f54bd18f3d62cfeeadcc1d4e6) | `` seanime: 3.8.7 -> 3.9.1 ``                                                                |
| [`4723448d`](https://github.com/NixOS/nixpkgs/commit/4723448d9e5a9cefe368b51dc353aeb61a1352a5) | `` wyoming-faster-whisper: 3.4.1 -> 3.5.0 ``                                                 |
| [`3f032439`](https://github.com/NixOS/nixpkgs/commit/3f0324396adcf7be4bf40711a7e72cbb32347de8) | `` apngasm_2: add missing runHooks ``                                                        |
| [`ea2f0aee`](https://github.com/NixOS/nixpkgs/commit/ea2f0aee5c5ff0d2ba79a83b410d5f3c3a10263c) | `` apngasm{,_2}: move to by-name/ ``                                                         |
| [`83da8329`](https://github.com/NixOS/nixpkgs/commit/83da83291cfcb65789203f94b09ea307f7e8df5f) | `` httpx: 1.9.0 -> 1.10.0 ``                                                                 |
| [`7c4913d3`](https://github.com/NixOS/nixpkgs/commit/7c4913d3da3a8ad2ee8b3e109b83fe531735ed12) | `` postgresqlPackages.pg_net: 0.20.3 -> 0.20.5 ``                                            |
| [`3eed4d9d`](https://github.com/NixOS/nixpkgs/commit/3eed4d9da6d489d2a6eaed222808758a51024177) | `` gqlgen: 0.17.93 -> 0.17.94 ``                                                             |
| [`b84b69cf`](https://github.com/NixOS/nixpkgs/commit/b84b69cf2f8a6ca39d3007c8d52bac93db3f06ba) | `` scantailor-{advanced,universal}: move to by-name/ ``                                      |
| [`feb71572`](https://github.com/NixOS/nixpkgs/commit/feb715729938376b392efb7cf8a7cad947fce692) | `` deadbeef-with-plugins: move to by-name/ ``                                                |
| [`97b6eb4a`](https://github.com/NixOS/nixpkgs/commit/97b6eb4a45478a61fa8435f806497ea4b6957cd7) | `` immich: 3.0.1 -> 3.0.2 ``                                                                 |
| [`9168fb05`](https://github.com/NixOS/nixpkgs/commit/9168fb05e660109e1502161f23534876b2b17b9a) | `` chromium,chromedriver: 150.0.7871.100 -> 150.0.7871.114 ``                                |
| [`dd77fea3`](https://github.com/NixOS/nixpkgs/commit/dd77fea3ec9044878794c4f3934c8f5757e7c591) | `` musicpresence: init at 2.3.6 ``                                                           |
| [`cf8dedce`](https://github.com/NixOS/nixpkgs/commit/cf8dedcece00f91b8b274317cda58bf832b53787) | `` neatvnc: 1.0.0 -> 1.0.1 ``                                                                |
| [`c5bec244`](https://github.com/NixOS/nixpkgs/commit/c5bec244e6b46c1dd0e749df330535ce2463d5db) | `` maintainers: add nonplay ``                                                               |
| [`d1858c5b`](https://github.com/NixOS/nixpkgs/commit/d1858c5b2d607d7ce15352b26b0ab98fa49924ec) | `` maintainers: add wiyba ``                                                                 |
| [`5778a66c`](https://github.com/NixOS/nixpkgs/commit/5778a66cc7961a5471712f9b812bcd265485150f) | `` openvox: set __structuredAttrs and __strictDeps to true with an override ``               |
| [`954b29c2`](https://github.com/NixOS/nixpkgs/commit/954b29c219e8bf8b526ad3536ea06112991135cb) | `` python3Packages.pgmpy: update source to actually build 1.1.2 ``                           |
| [`871cec4b`](https://github.com/NixOS/nixpkgs/commit/871cec4b49d3dde19191018983d302c424821937) | `` flix: 0.75.0 -> 0.75.1 ``                                                                 |
| [`3347d985`](https://github.com/NixOS/nixpkgs/commit/3347d985f201c32b8093a8701f07f34cab18e6e3) | `` Revert "hdrhistogram_c: 0.11.9 -> 0.11.10" ``                                             |
| [`23cfb4e2`](https://github.com/NixOS/nixpkgs/commit/23cfb4e2f481f310eb92a489c0a4505c0f65934e) | `` emacsPackages.majutsu: init at 0.6.0-unstable-2026-07-09 ``                               |
| [`f56a8f7f`](https://github.com/NixOS/nixpkgs/commit/f56a8f7f28d8867dffbbb8d5210f76416e4c29cf) | `` swaylock: 1.8.5 -> 1.8.6 ``                                                               |
| [`64010374`](https://github.com/NixOS/nixpkgs/commit/64010374df8cf518f4bc421b57a56b21aa9fb614) | `` nerva: 1.40.0 -> 1.40.1 ``                                                                |
| [`f7f20510`](https://github.com/NixOS/nixpkgs/commit/f7f20510b6e4846eacb4218ea2d17ae70a318314) | `` libretro.quicknes: 0-unstable-2026-05-11 -> 0-unstable-2026-07-06 ``                      |
| [`f993ac2e`](https://github.com/NixOS/nixpkgs/commit/f993ac2ef564c312e6e7fa7b6b1e836e13cb4299) | `` libretro.snes9x2010: 0-unstable-2026-06-29 -> 0-unstable-2026-07-07 ``                    |
| [`f2b17160`](https://github.com/NixOS/nixpkgs/commit/f2b17160ce69df964c2ef7e5ca5d560d3498dcf3) | `` terraform-providers.goharbor_harbor: 3.12.0 -> 3.12.1 ``                                  |
| [`e7d35f9d`](https://github.com/NixOS/nixpkgs/commit/e7d35f9d19719140d4e20e619912a82ca811dce7) | `` wordpress_7_0: 7.0 -> 7.0.1 ``                                                            |
| [`78df2e66`](https://github.com/NixOS/nixpkgs/commit/78df2e6667ceebc3b5f5ea652f1f52813763840b) | `` python3Packages.sunpy: 7.1.2 -> 8.0.0 ``                                                  |
| [`463dc5b4`](https://github.com/NixOS/nixpkgs/commit/463dc5b43db782a1ca07d75cb027c0139fc0d71f) | `` python3Packages.drms: 0.9.0 -> 0.9.1 ``                                                   |
| [`8f741b30`](https://github.com/NixOS/nixpkgs/commit/8f741b30cc629ac2b0e3e78d2ce4a9a2cd67ac44) | `` vimPlugins.zk-nvim: 0.4.9 -> 0.4.10 ``                                                    |
| [`febadd2d`](https://github.com/NixOS/nixpkgs/commit/febadd2d3662e5759be3cf61f36ebd9bfaa644e2) | `` vimPlugins.helpview.nvim: 2.1.2-unstable-2026-05-14 -> 2.2.0 ``                           |
| [`1d0b12dc`](https://github.com/NixOS/nixpkgs/commit/1d0b12dc52b66ef0c9a6762dc4adf23aa2e47d85) | `` vimPlugins.oklch-color-picker-nvim: 5.0.0 -> 5.0.2 ``                                     |
| [`a4664ec2`](https://github.com/NixOS/nixpkgs/commit/a4664ec29dce9bf05f692f05c40a9abb701ce9b3) | `` vimPlugins.otter-nvim: 2.14.5 -> 2.14.6 ``                                                |
| [`5d487e0b`](https://github.com/NixOS/nixpkgs/commit/5d487e0b1c3804a97a55ff7cef6c25d23bbb4595) | `` vimPlugins.project-nvim: 5.1.0-1 -> 5.1.1-1 ``                                            |
| [`5a494387`](https://github.com/NixOS/nixpkgs/commit/5a4943876c235746d3650e9cb99c4d5f7ddfc0e1) | `` vimPlugins: update on 2026-07-09 ``                                                       |
| [`36e3a3df`](https://github.com/NixOS/nixpkgs/commit/36e3a3df5060e1d4213576b8a0b28e2cad52b44d) | `` aeron: 1.49.0 -> 1.50.2 and clean up legacy versions ``                                   |
| [`c840b301`](https://github.com/NixOS/nixpkgs/commit/c840b30162d78bcb6f50749c4a2feb9480d8e070) | `` oo7-pam: init at 0.6.0 ``                                                                 |
| [`48d200a4`](https://github.com/NixOS/nixpkgs/commit/48d200a43b725b22a7f1d49a4343a49d8212dd96) | `` python3Packages.parfive: disable broken tests ``                                          |
| [`fb9afd58`](https://github.com/NixOS/nixpkgs/commit/fb9afd5877ed1c1ebda547664d562f17addd7f61) | `` vulkan-validation-layers: fix build by disabling UPDATE_DEPS ``                           |
| [`e1e21c69`](https://github.com/NixOS/nixpkgs/commit/e1e21c69501314478cf573c8b8b12cf70a3537e5) | `` wlroots_0_20: 0.20.1 -> 0.20.2 ``                                                         |
| [`1725027c`](https://github.com/NixOS/nixpkgs/commit/1725027c8d236b92c179a61b5995d078547ab6c0) | `` raycast-beta: 0.65.1.0 -> 0.68.0.0 ``                                                     |
| [`e4ded4af`](https://github.com/NixOS/nixpkgs/commit/e4ded4af8fe53b9eaa8d17a0ccd098111f129474) | `` openvox: create an alias for puppet and remove puppet ``                                  |
| [`7eea08bc`](https://github.com/NixOS/nixpkgs/commit/7eea08bc49c3aec2654bb3c8a5583c20e7017958) | `` openvox: init at 8.26.2 ``                                                                |
| [`cb83e5fc`](https://github.com/NixOS/nixpkgs/commit/cb83e5fc62dd57bd14bcc3e7f68a19574574f36e) | `` mise: 2026.7.2 -> 2026.7.4 ``                                                             |
| [`c9a0526c`](https://github.com/NixOS/nixpkgs/commit/c9a0526cdb8072d2443ba88fb222943c7eeeb4cf) | `` python3Packages.google-maps-routing: 3.31.3 -> 0.11.0 ``                                  |
| [`ddc538b0`](https://github.com/NixOS/nixpkgs/commit/ddc538b0a6318e4a896bb4f9280213b18fb2152a) | `` cage: 0.3.0 -> 0.3.1 ``                                                                   |
| [`51d3788b`](https://github.com/NixOS/nixpkgs/commit/51d3788b0811d52492af78749f5c67255ebbbc64) | `` deno: skip happy eyeballs unit test ``                                                    |
| [`57f5d6ae`](https://github.com/NixOS/nixpkgs/commit/57f5d6aed97a0971a9306bb08a5d6e7f325ce6e0) | `` cormorant: init at 4.002 ``                                                               |
| [`c6ff2a8c`](https://github.com/NixOS/nixpkgs/commit/c6ff2a8cc7986fe4c37c440f090d36ca1f207712) | `` evcc: 0.309.1 -> 0.311.1 ``                                                               |
| [`d635569d`](https://github.com/NixOS/nixpkgs/commit/d635569d6639f4f4744fb5cc8a1d70fcb259eceb) | `` lakectl: 1.82.0 -> 1.83.0 ``                                                              |
| [`20882906`](https://github.com/NixOS/nixpkgs/commit/2088290617775d1f6d3cd1bb154f6cf470e7942a) | `` pijul: 1.0.0-beta.14 -> 1.0.0-beta.18 ``                                                  |
| [`6eb4c38c`](https://github.com/NixOS/nixpkgs/commit/6eb4c38c9826874eb34bb9cb466137daccc67262) | `` dotenvx: 1.75.1 -> 2.3.2 ``                                                               |
| [`77befb53`](https://github.com/NixOS/nixpkgs/commit/77befb5308748d34478c5c395d6729da1aaa68f3) | `` _7zip-zstd-rar: 26.02-v1.5.7-R1 -> 26.02-v1.5.7-R2 ``                                     |
| [`e2db7f2f`](https://github.com/NixOS/nixpkgs/commit/e2db7f2f840376acd14100115a4c57b80e9f53af) | `` apfel-llm: 1.7.0 -> 1.8.3 ``                                                              |
| [`74713c87`](https://github.com/NixOS/nixpkgs/commit/74713c87b6e88a94465493a2b537ab49c4e7f941) | `` netgen-vlsi: 1.5.321 -> 1.5.323 ``                                                        |
| [`7c640aaf`](https://github.com/NixOS/nixpkgs/commit/7c640aaf5c949e6dc917f02c84c27591e7e753be) | `` radicle-ci-broker: 0.29.0 -> 0.30.0 ``                                                    |
| [`fe79937b`](https://github.com/NixOS/nixpkgs/commit/fe79937b56cddaf4ef44a8724cdf7af51498ce51) | `` gopls: 0.22.0 -> 0.23.0 ``                                                                |
| [`5513db60`](https://github.com/NixOS/nixpkgs/commit/5513db60eb997ac785c69695db0d5f9138e90c48) | `` nix-unit: 2.34.0 -> 2.34.1 ``                                                             |
| [`8a784fb9`](https://github.com/NixOS/nixpkgs/commit/8a784fb9e7c6e19a45369d8ca96a02bf45335ed3) | `` espflash: 4.4.0 -> 4.5.0 ``                                                               |
| [`e362fcd1`](https://github.com/NixOS/nixpkgs/commit/e362fcd197f76d6a7ee04ae5823b29ea8ef9909c) | `` kodi: fix build with giflib 6 ``                                                          |
| [`3d97d8db`](https://github.com/NixOS/nixpkgs/commit/3d97d8db4c77415da4bc515ba52fca1c39effb6a) | `` envconsul: 0.13.4 -> 0.14.0 ``                                                            |
| [`00d8b883`](https://github.com/NixOS/nixpkgs/commit/00d8b883b94011902809cf47e89a377c359e1bc3) | `` terraform-providers.auth0_auth0: 1.51.0 -> 1.52.0 ``                                      |
| [`bb144c82`](https://github.com/NixOS/nixpkgs/commit/bb144c824fe89b19fd307ba4edcd5b4e0844fbfb) | `` go-arch-lint: 1.15.0 -> 1.16.0 ``                                                         |
| [`55e20144`](https://github.com/NixOS/nixpkgs/commit/55e20144b954f4669ff6357fafccd01dc0636b96) | `` mudlet: 4.20.1 -> 4.22.0 ``                                                               |
| [`58eb0e3d`](https://github.com/NixOS/nixpkgs/commit/58eb0e3d00f8559f0b590e72456b9bc2220bb6ad) | `` webkitgtk_6_0: 2.52.4 → 2.52.5 ``                                                         |
| [`e559f917`](https://github.com/NixOS/nixpkgs/commit/e559f917d674c0bea68d8db3734214db61ee1fcc) | `` remnote: 1.26.20 -> 1.26.30 ``                                                            |
| [`2b389d47`](https://github.com/NixOS/nixpkgs/commit/2b389d470ba9a42551736efb4214d3dfb731b7b4) | `` gvm-libs: 23.7.0 -> 23.8.0 ``                                                             |
| [`ee80f79f`](https://github.com/NixOS/nixpkgs/commit/ee80f79fbd24deffbe36c31d7b52d85936b5fa79) | `` zed-editor: 1.9.0 -> 1.10.0 ``                                                            |
| [`fd2b867b`](https://github.com/NixOS/nixpkgs/commit/fd2b867b7996b55208d1eb159a2d339e20e4d0cb) | `` python3Packages.modbus-connection: 3.3.0 -> 3.4.1 ``                                      |

*... and 377 more commits (truncated)*