### PR TITLE
ci: drop redundant hadolint job from deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -47,20 +47,9 @@ jobs:
           echo "Workflow dispatch reason: $INPUTS_REASON"
           echo "Use test image: $INPUTS_USE_TEST_IMAGE"
 
-  hadolint:
-    name: Run hadolint against docker files
-    runs-on: ubuntu-24.04
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - name: Pull hadolint/hadolint:latest Image
-        run: docker pull hadolint/hadolint:latest
-      - name: Run hadolint against Dockerfiles
-        run: docker run --rm -i -v "$PWD":/workdir --workdir /workdir --entrypoint hadolint hadolint/hadolint --ignore DL3003 --ignore DL3006 --ignore DL3010 --ignore DL4001 --ignore DL3007 --ignore DL3008 --ignore SC2068 --ignore DL3007 --ignore SC1091 --ignore DL3013 --ignore DL3010 $(find . -type f -iname "Dockerfile*")
-
   build_and_push:
     name: Image Build & Push
     uses: sdr-enthusiasts/common-github-workflows/.github/workflows/sdre.yml@bcf0b94a192e7ca9630f788ecc16acd999541404 # main
-    needs: [hadolint]
     with:
       push_enabled: true
       push_destinations: ghcr.io


### PR DESCRIPTION
## Problem

This job ran hadolint from unpinned `hadolint/hadolint:latest`, so it silently adopted upstream rule changes. hadolint v2.15.0 (published 2026-07-30T13:39:01Z) extended `DL3025` to fire on `HEALTHCHECK ... CMD` ([#1209](https://github.com/hadolint/hadolint/pull/1209)) and added `DL3064` — the breakage that has been working through this fleet (`docker-shipfeeder#169`, `docker-adsb-ultrafeeder#278`, `docker-adsbhub#125` and others).

This Dockerfile happens to be clean at 2.15.1 — it declares no `HEALTHCHECK` — so nothing was breaking here yet:

```console
$ hadolint --config <shared ruleset> Dockerfile   # 2.15.1
rc=0
```

`build_and_push` gated on the job via `needs: [hadolint]`, so a future rule change would have **blocked the image build outright** rather than merely painting the run red.

## Changes

Removes the `hadolint` job and the `needs: [hadolint]` reference. Leaving the reference would make the workflow invalid.

Coverage is unchanged: `check_docker = true`, so `lint.yaml` already lints the Dockerfile on every PR via pre-commit against a `flake.lock`-pinned version rather than a floating tag.

## Verification

```console
$ yq '.jobs | keys' .github/workflows/deploy.yml
- workflow-dispatch
- build_and_push

dangling needs: none
```

- `nix develop -c pre-commit run --all-files`: green, including `check-github-workflows` (schema validation) and `hadolint`
- No Dockerfile changes, so no image can be affected
- No hooks bypassed; no `--no-verify`
